### PR TITLE
#13 Load documents from a text file

### DIFF
--- a/week2_tasks/boolean_search.py
+++ b/week2_tasks/boolean_search.py
@@ -1,13 +1,16 @@
 from sklearn.feature_extraction.text import CountVectorizer
-import xml.dom.minidom
+import re
 
+# read articles from file
 with open('enwiki-20181001-corpus.1000-articles.txt', encoding='utf8') as f:
     content = f.read()
 
-documents = content.split('</article>')
-
-#TODO drop <article name"..."> from the beginning of each article
-#Maybe save article names for referencing?
+# split by closing article tag, and then remove opening tag
+# save document titles in separate array
+documents = content.strip().split('</article>')
+p = re.compile('^\s*<article\s+name="(.*?)"\s*>\s*')
+documents_titles = [p.match(document).group(1) for document in documents if document and p.match(document)]
+documents = [re.sub(p, "", document) for document in documents if document and p.match(document)]
 
 cv = CountVectorizer(lowercase=True, binary=True, stop_words=None)
 sparse_matrix = cv.fit_transform(documents)

--- a/week2_tasks/boolean_search.py
+++ b/week2_tasks/boolean_search.py
@@ -1,10 +1,13 @@
 from sklearn.feature_extraction.text import CountVectorizer
+import xml.dom.minidom
 
-# Task
-documents = ["This is a silly example",
-             "A better example",
-             "Nothing to see here",
-             "This is a great and long example"]
+with open('enwiki-20181001-corpus.1000-articles.txt', encoding='utf8') as f:
+    content = f.read()
+
+documents = content.split('</article>')
+
+#TODO drop <article name"..."> from the beginning of each article
+#Maybe save article names for referencing?
 
 cv = CountVectorizer(lowercase=True, binary=True, stop_words=None)
 sparse_matrix = cv.fit_transform(documents)


### PR DESCRIPTION
Added a file, read it to contents and then split it into articles with some regexing. This saves the titles into document_titles if we want to display those with the results.

And, for an example, did this all in a separate branch and created this pull request. This branch is currently up to date, so git should be able to merge the pull request automatically after approving. Also, beware, if you merge and use this code, it will try printing a horrible amount of results, since the queries match a lot of material, but #14 should fix that.